### PR TITLE
Accessibility fixes

### DIFF
--- a/about.html
+++ b/about.html
@@ -30,12 +30,12 @@
 			</div>
 		</div>
 	</div>
-	<div id="page"> 
+	<div id="page">
 		<div class='container'>
 			<div class="row">
 				<div class="col-xs-12 col-sm-6 text-center">
 					<h1>EarlyOakland</h1>
-					<p>a project of</p>  
+					<p>a project of</p>
 					<a href='/'><img width="200px" height="77px" src='oologo.png' alt='early childhood services oakland' /></a>
 				</div>
 				<div class="col-xs-12 col-sm-6">
@@ -89,9 +89,9 @@
 					<p>Technologies used:</p>
 					<ul>
 						<li><a href='http://jquery.com'>jQuery</a></li>
-						<li><a href='http://code.google.com/apis/maps/documentation/javascript/'>Google Maps API V3</a></li> 
+						<li><a href='http://code.google.com/apis/maps/documentation/javascript/'>Google Maps API V3</a></li>
 						<li><a href='http://www.google.com/fusiontables'>Google Fusion Tables</a></li>
-					</ul> 
+					</ul>
 
 					<p>If you are interested, all the code for this project is up on <a href='http://github.com'>github</a>:</p>
 					<ul>
@@ -99,7 +99,7 @@
 					</ul>
 
 					<h2 id="credits">Credits</h2>
-					<p>This site was built, designed and hosted by Steve Spiker & Cris Cristina at the International Open Data Day Hackathon hosted by <a href='http://opendataday.openoakland.org/'>OpenOakland</a> and with continued support from Max Ogden, Rob Chiniquy, Tarik Bennet, Josh Morrow and Felix Sargent. The original map interface was built on the template by <a href="http://derekeder.com">Derek Eder</a>.</p> 			
+					<p>This site was built, designed and hosted by Steve Spiker & Cris Cristina at the International Open Data Day Hackathon hosted by <a href='http://opendataday.openoakland.org/'>OpenOakland</a> and with continued support from Max Ogden, Rob Chiniquy, Tarik Bennet, Josh Morrow and Felix Sargent. The original map interface was built on the template by <a href="http://derekeder.com">Derek Eder</a>.</p>
 
 					<hr />
 					<p class='mute'>A project by <a href='http://openoakland.org'>OpenOakland</a></p>
@@ -111,7 +111,7 @@
 
 
 	<!--MODALS!-->
-	<div class="modal fade bs-example-modal-lg" id="suggestions"tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
+	<div class="modal fade bs-example-modal-lg" id="suggestions"tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
 		<div class="modal-dialog modal-lg">
 			<div class="modal-content">
 				<div class="modal-header">
@@ -119,9 +119,9 @@
 					<h4 class="modal-title" id="myModalLabel">Finding and Enrolling in Early Education Programs in Oakland: </h4>
 				</div>
 
-				<div class="row featurette"> 
+				<div class="row featurette">
 					<div class="col-md-3">
-						<img class="featurette-image img-responsive" src="images/slide500.jpg" alt="slides">
+						<img class="featurette-image img-responsive" src="images/slide500.jpg" alt="Child on slide">
 					</div>
 					<div class="col-md-9">
 						<ul>
@@ -145,12 +145,12 @@
 	</div>
 
 	<!--MODALS!-->
-	<div class="modal fade bs-example-modal-lg" id="faq"tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
+	<div class="modal fade bs-example-modal-lg" id="faq"tabindex="-1" role="dialog" aria-labelledby="myModalLabel2" aria-hidden="true">
 		<div class="modal-dialog modal-lg">
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-					<h4 class="modal-title" id="myModalLabel">Frequently Asked Questions</h4>
+					<h4 class="modal-title" id="myModalLabel2">Frequently Asked Questions</h4>
 				</div>
 				<ul class="faq">
 					<li><strong>What programs are included in this website?</strong></li>

--- a/css/style.css
+++ b/css/style.css
@@ -14,13 +14,13 @@ body
 }
 .navbar-static-top
 {
-	background:#393;
-	opacity: .75;
+	background: rgba(34, 136, 0, 1);
+    border: 0;
+    margin-bottom: 0;
 }
 .navbar-inverse .navbar-nav>li>a, .navbar-inverse .navbar-brand
 {
 	color:#FFF;
-	text-shadow: 0 1px 2px rgba(0,0,0,.6);
 }
 .navbar-inverse .navbar-nav>li>a:hover, .navbar-inverse .navbar-brand:hover
 {
@@ -37,17 +37,17 @@ body
 }
 .btn-primary
 {
-	background-color:#393;
+	background-color: rgba(34, 136, 0, 1);
 	box-shadow: 0 1px 2px rgba(0,0,0,.6);
 	border:1px solid #282;
 }
 .btn-primary:hover
 {
-	background-color:#282;
+	background-color: #282;
 }
 .btn-primary a
 {
-		text-shadow: 0 1px 2px rgba(0,0,0,.6);
+	text-shadow: 0 1px 2px rgba(0,0,0,.6);
 }
 ul.faq
 {
@@ -106,9 +106,9 @@ a { color: #4B58A6; }
 
 #map_canvas { min-height: 400px; }
 
-.filter-box { 
-  height: 15px; 
-  width: 15px;  
+.filter-box {
+  height: 15px;
+  width: 15px;
   display: inline-block;
   *border-right-width: 2px;
   *border-bottom-width: 2px;
@@ -117,7 +117,7 @@ a { color: #4B58A6; }
           border-radius: 5px;
   -webkit-background-clip: padding-box;
      -moz-background-clip: padding;
-          background-clip: padding-box; 
+          background-clip: padding-box;
 }
 
 .filter-yellow { background-color: #FBF358; }
@@ -132,8 +132,8 @@ canvas {-ms-touch-action: double-tap-zoom;}
 .popup-marker-data p { margin-bottom: 5px; }
 .popup-marker-data hr { margin: 5px 0 5px 0; }
 .popup-marker-data .dl-horizontal { margin-top: 5px; }
-.popup-marker-data dt { width: 105px; }	
-.popup-marker-data dd { margin-left: 115px; }	
+.popup-marker-data dt { width: 105px; }
+.popup-marker-data dd { margin-left: 115px; }
 
 .dl-horizontal dt {
 float: left;

--- a/css/style.css
+++ b/css/style.css
@@ -7,6 +7,11 @@ body
 {
 	max-width: 970px;
 }
+
+#myCarousel {
+    margin-top: -20px;
+}
+
 .carousel-caption
 {
 	max-width: 500px;
@@ -16,11 +21,10 @@ body
 {
 	background: rgba(34, 136, 0, 1);
     border: 0;
-    margin-bottom: 0;
 }
 .navbar-inverse .navbar-nav>li>a, .navbar-inverse .navbar-brand
 {
-	color:#FFF;
+	color: #FFF;
 }
 .navbar-inverse .navbar-nav>li>a:hover, .navbar-inverse .navbar-brand:hover
 {

--- a/find.html
+++ b/find.html
@@ -45,7 +45,7 @@
 
       <div class='col-xs-12 col-sm-3'>
         <p align="center">
-          <img src='images/eologo.png' width="150px"></p>
+          <img src='images/eologo.png' width="150px" alt="Early Oakland logo"></p>
         <p>
           EarlyOakland is a campaign by the Oakland Education Cabinet to help Oaklanders find affordable early care and education services. You can use the map of to find subsidized programs for eligible families and children including HeadStart and Child Development Centers. Stay tuned for more resources!
           <a href='about.html'><strong>Read more &raquo;</strong></a>
@@ -72,7 +72,10 @@
           <h4>
             Address (<a id='find_me' href='#'>find me</a>)
           </h4>
+          <label>
+          <span class='sr-only'>Enter an address or an intersection</span>
           <input class='input-block-level' id='search_address' placeholder='Enter an address or an intersection' type='text' />
+          </label>
           <input class='btn btn-primary' id='search' type='button' value='Search' />
         </div>
 

--- a/find.html
+++ b/find.html
@@ -42,14 +42,14 @@
   </div>
   <div class='container-fluid'>
     <div class='row-fluid'>
-      
+
       <div class='col-xs-12 col-sm-3'>
         <p align="center">
           <img src='images/eologo.png' width="150px"></p>
         <p>
           EarlyOakland is a campaign by the Oakland Education Cabinet to help Oaklanders find affordable early care and education services. You can use the map of to find subsidized programs for eligible families and children including HeadStart and Child Development Centers. Stay tuned for more resources!
           <a href='about.html'><strong>Read more &raquo;</strong></a>
-          
+
           <p>
             If you cannot find the service you are looking for or need more assistance contact <a href='http://www.bananasinc.org' target="_blank">BANANAS</a> or call (510) 658-0381.
           </p>
@@ -59,14 +59,14 @@
             <a href='http://www.oaklandnet.com' target="_blank">the Oakland Education Cabinet</a>
             .
           </p>
-          
+
         </p>
       </div>
-      
+
       <div class='col-xs-12 col-sm-9 col-md-6' id="mapContainer">
         <div id='map_canvas'></div>
       </div>
-      
+
       <div class='col-xs-12 col-sm-9 col-md-3'>
         <div class='well'>
           <h4>
@@ -185,24 +185,24 @@
           </ul>
 
         </div>
-        
+
 
       </div>
 
     </div>
   </div>
   <!--MODALS!-->
-  <div class="modal fade bs-example-modal-lg" id="suggestions"tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
+  <div class="modal fade bs-example-modal-lg" id="suggestions"tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
           <h4 class="modal-title" id="myModalLabel">Finding and Enrolling in Early Education Programs in Oakland: </h4>
         </div>
-        
-        <div class="row featurette"> 
+
+        <div class="row featurette">
           <div class="col-md-3">
-            <img class="featurette-image img-responsive" src="images/slide500.jpg" alt="slides">
+            <img class="featurette-image img-responsive" src="images/slide500.jpg" alt="Child on slide">
           </div>
           <div class="col-md-9">
         <ul>
@@ -223,18 +223,18 @@
 
           </div>
         </div>
-        
+
       </div>
     </div>
   </div>
 
   <!--MODALS!-->
-  <div class="modal fade bs-example-modal-lg" id="faq"tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
+  <div class="modal fade bs-example-modal-lg" id="faq"tabindex="-1" role="dialog" aria-labelledby="myModalLabel2" aria-hidden="true">
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" id="myModalLabel">Frequently Asked Questions</h4>
+          <h4 class="modal-title" id="myModalLabel2">Frequently Asked Questions</h4>
         </div>
         <ul class="faq">
         <li><strong>What programs are included in this website?</strong></li>
@@ -258,43 +258,43 @@
         <strong><%= campus_site_name.value %></strong><br />
         <%= streetaddress.value %><br />
         <%= telephone_number.value %><br />
-        <% if ( typeof web_address !== 'undefined' ) { %> 
+        <% if ( typeof web_address !== 'undefined' ) { %>
         <a href="<%= web_address.value %>">Website</a><br />
         <% } %>
         <h5>Program Details</h5>
         <hr>
         <dl class="dl-horizontal">
-            <% if ( typeof director_name !== 'undefined' ) { %> 
+            <% if ( typeof director_name !== 'undefined' ) { %>
                 <dt><%= director_name.name %>:</dt>
                 <dd><%= director_name.value %></dd>
             <% } %>
 
-            <% if ( typeof ages_served !== 'undefined' ) { %> 
+            <% if ( typeof ages_served !== 'undefined' ) { %>
                 <dt><%= ages_served.name %>:</dt>
                 <dd><%= ages_served.value %></dd>
             <% } %>
-            
-            <% if ( half_day.value === 'yes' || full_day.value === 'yes' ) { 
-                    if ( half_day.value === 'yes' && full_day.value === 'yes' ) { 
+
+            <% if ( half_day.value === 'yes' || full_day.value === 'yes' ) {
+                    if ( half_day.value === 'yes' && full_day.value === 'yes' ) {
                         var time = half_day.name + ' and ' + full_day.name
-                    } else if ( half_day.value === 'yes' ) { 
-                        var time = half_day.name 
+                    } else if ( half_day.value === 'yes' ) {
+                        var time = half_day.name
                     } else {
-                        var time = full_day.name 
-                    } %> 
+                        var time = full_day.name
+                    } %>
 
                 <dt>Time:</dt>
                 <dd><%= time %></a></dd>
             <% } %>
 
-            <% if ( before_school.value === 'yes' || after_school.value === 'yes' ) { 
-                    if ( before_school.value === 'yes' && after_school.value === 'yes' ) { 
+            <% if ( before_school.value === 'yes' || after_school.value === 'yes' ) {
+                    if ( before_school.value === 'yes' && after_school.value === 'yes' ) {
                         var school_hours = before_school.name + ' or ' + after_school.name
-                    } else if ( before_school.value === 'yes' ) { 
-                        var school_hours = before_school.name 
+                    } else if ( before_school.value === 'yes' ) {
+                        var school_hours = before_school.name
                     } else {
-                        var school_hours = after_school.name 
-                    } %> 
+                        var school_hours = after_school.name
+                    } %>
 
                 <dt>School Hours:</dt>
                 <dd><%= school_hours %></a></dd>
@@ -322,6 +322,6 @@
   ga('send', 'pageview');
 
 </script>
-  
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -83,22 +83,22 @@
             <div class="carousel-caption">
               <h1>We're here to help.</h1>
               <p>Early learning programs and services are located near you, and EarlyOakland.Org is here to support you.  Many of these programs are free or low-cost.</p>
-              <p><a class="btn btn-lg btn-primary" href="#learn" role="button">Find Services</a></p>
+              <p><a class="btn btn-lg btn-primary" href="#learn" role="button">Find services</a></p>
             </div>
           </div>
         </div>
         <div class="item" style="background: #833dc7 url(images/startrotate1.jpg);">
           <div class="container">
             <div class="carousel-caption">
-              <h1>Early Learning Programs Work</h1>
+              <h1>Early learning programs work</h1>
               <p>Whatever effort it takes to get your child, particularly your 3 to 5 year old into an early learning program will be worth it--you will see the benefits throughout your child's life.</p>
-              <p><a class="btn btn-lg btn-primary" href="#why" role="button">Learn More</a></p>
+              <p><a class="btn btn-lg btn-primary" href="#why" role="button">Learn More about learning programs</a></p>
             </div>
           </div>
         </div>
       </div>
-      <a class="left carousel-control" href="#myCarousel" data-slide="prev"><span class="glyphicon glyphicon-chevron-left"></span></a>
-      <a class="right carousel-control" href="#myCarousel" data-slide="next"><span class="glyphicon glyphicon-chevron-right"></span></a>
+      <a class="left carousel-control" href="#myCarousel" data-slide="prev"><span class="glyphicon glyphicon-chevron-left"></span><span class="sr-only">Go to previous slide</span></a>
+      <a class="right carousel-control" href="#myCarousel" data-slide="next" alt="Go to next slide"><span class="glyphicon glyphicon-chevron-right"></span><span class="sr-only">Go to next slide</span></a>
     </div><!-- /.carousel -->
 
 
@@ -112,9 +112,9 @@
 <div class="container">
      <hr class="featurette-divider">
 
-      <div class="row featurette"> <a name="why"></a>
+      <div class="row featurette">
         <div class="col-md-7">
-          <h2 class="featurette-heading">Why should you consider enrolling your child?</h2>
+          <h2 class="featurette-heading" name="why">Why should you consider enrolling your child?</h2>
           <p class="lead">Children thrive when they are in a supervised learning environment where they socialize and learn with other children and engage in age-appropriate learning.</p>
         <p class="lead">To begin the enrollment process, Call or visit </p>
            <ul>
@@ -147,7 +147,7 @@
 
       <hr class="featurette-divider">
 
-      <div class="row featurette"> <a name="learn"></a>
+      <div class="row featurette">
         <div class="col-md-7">
           <h2 name="learn" class="featurette-heading">How Do I Find These Services? <em>Easy!</em></h2>
           <p class="lead">Follow any button on this site to Find Services and you'll see a map that lets you pick your child's age, you can then see contact and enrollment information about services close to your home or work.  You can call too!</p>
@@ -173,7 +173,7 @@
       <!-- Four columns of text for site sponsors -  -->
       <div class="row">
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www.bananasinc.org/" ><img class="img" src="images/bananas180.png" alt="Bananas" width="100%"></a>
+          <a href="http://www.bananasinc.org/" ><img class="img" src="images/bananas180.png" alt="Bananas Inc" width="100%"></a>
 <!--                  <h3>Bananas, Inc.</h3> -->
         </div><!-- /.col-lg-3 -->
         <div class="col-xs-12 col-sm-3">

--- a/index.html
+++ b/index.html
@@ -23,11 +23,11 @@
 
     <!-- Custom styles for this template -->
     <link href="css/carousel.css" rel="stylesheet">
-    
+
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 
   </head>
-  
+
 <!-- NAVBAR
 ================================================== -->
   <body>
@@ -72,7 +72,7 @@
         <div class="item active" style="background-image:url(images/startrotate1.jpg);">
           <div class="container">
             <div class="carousel-caption">
-              <img src="images/eologo180.png" alt="logo" />
+              <img src="images/eologo180.png" alt="Early Oakland" />
               <p>Learning is a lifelong process that starts the day we are born.</p>
               <p><a class="btn btn-lg btn-primary" href="find.html" role="button">Enroll your child today</a></p>
             </div>
@@ -102,7 +102,7 @@
     </div><!-- /.carousel -->
 
 
-  
+
     <!-- Marketing messaging and featurettes
     ================================================== -->
     <!-- Wrap the rest of the page in another container to center all the content. -->
@@ -122,19 +122,19 @@
         <li class="lead"><a href="http://www.ousd.k12.ca.us/domain/92">Oakland Unified School District Early Childhood Education</a>: (510) 273-1590</li>
         <li class="lead"><a href="http://www2.oaklandnet.com/Government/o/DHS/o/ChildrenYouthServices/OAK022077">Oakland Head Start</a>: (510) 238-3165</li>
         <li class="lead"><a href="http://www.unitycouncil.org/head-start-and-early-head-start/">Unity Council Head Start</a>: (510) 535-6102</li>
-        
+
            <p><a class="btn btn-lg btn-primary" href="find.html" role="button">Find Services</a></p>
         </div>
         <div class="col-md-5">
-          <img class="featurette-image img-responsive" src="images/princess500.jpg" alt="pricess">
+          <img class="featurette-image img-responsive" src="images/princess500.jpg" alt="Child drawing a picture">
         </div>
       </div>
 
       <hr class="featurette-divider">
 
-      <div class="row featurette"> 
+      <div class="row featurette">
         <div class="col-md-5">
-          <img class="featurette-image img-responsive" src="images/carwash.jpg" alt="joy">
+          <img class="featurette-image img-responsive" src="images/carwash.jpg" alt="Happy child washing a car">
         </div>
         <div class="col-md-7">
           <h2 class="featurette-heading">What age can my child be?</h2>
@@ -155,7 +155,7 @@
 
         </div>
         <div class="col-md-5">
-          <img class="featurette-image img-responsive" src="images/map.jpg" alt="map">
+          <img class="featurette-image img-responsive" src="images/map.jpg" alt="Screenshot of Find Services feature">
         </div>
       </div>
 
@@ -163,7 +163,7 @@
 </div> <!-- /.container-->
 
       <!-- /END THE FEATURETTES -->
-      
+
           <h1 class="text-center">Early learning is power.</h1>
 <hr />
 
@@ -173,19 +173,19 @@
       <!-- Four columns of text for site sponsors -  -->
       <div class="row">
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www.bananasinc.org/" ><img class="img" src="images/bananas180.png" alt="bananas" width="100%"></a>
+          <a href="http://www.bananasinc.org/" ><img class="img" src="images/bananas180.png" alt="Bananas" width="100%"></a>
 <!--                  <h3>Bananas, Inc.</h3> -->
         </div><!-- /.col-lg-3 -->
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www.ousd.k12.ca.us/Domain/92" ><img class="img" src="images/sprout180.png" alt="ece" width="100%"></a>
+          <a href="http://www.ousd.k12.ca.us/Domain/92" ><img class="img" src="images/sprout180.png" alt="OUSD Sprout Early Education" width="100%"></a>
 <!--                  <h3>OUSD ECE</h3> -->
         </div><!-- /.col-lg-4 -->
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www2.oaklandnet.com/Government/o/DHS/o/ChildrenYouthServices/OAK022077" ><img class="img" src="images/headstart180.png" alt="headstart" width="100%"></a>
+          <a href="http://www2.oaklandnet.com/Government/o/DHS/o/ChildrenYouthServices/OAK022077" ><img class="img" src="images/headstart180.png" alt="Oakland Head Start" width="100%"></a>
 <!--          <h3>Oakland HeadStart</h3>-->
         </div><!-- /.col-lg-3 -->
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www.unitycouncil.org/head-start-and-early-head-start/" ><img class="img" src="images/unity180.png" alt="unity" width="100%"></a>
+          <a href="http://www.unitycouncil.org/head-start-and-early-head-start/" ><img class="img" src="images/unity180.png" alt="The Unity Project" width="100%"></a>
 <!--          <h3>Unity Council Preschools</h3>-->
         </div><!-- /.col-lg-3 -->
       </div><!-- /.row -->
@@ -196,7 +196,7 @@
 <div class="container" >
   <h3 class="text-center">Thanks to the following partners</h3>
 	<div class="col-xs-12 col-md-6">
-    <p class="text-center">City of Oakland Department of Human Services & Office of Children Youth and Families</p>   
+    <p class="text-center">City of Oakland Department of Human Services & Office of Children Youth and Families</p>
 		<p class="text-center">Alameda County Community Action Partnership</p>
 		<p class="text-center">Alameda County Early Care and Education Planning Council</p>
 		<p class="text-center">Alameda County Public Health Department</p>
@@ -221,7 +221,7 @@
 </div> <!-- container -->
 <hr />
 
- 
+
 <div class="container">
 <h3 class="text-center" >We appreciate the generosity of our supporters:</h3>
 </div> <!-- /.container-->
@@ -252,10 +252,10 @@
       <div class="row">
         <div class="col-xs-12 col-sm-4">
 			<h2 class="text-center">Built in partnership with</h2>
-				<a href="http://openoakland.org"><img src="images/ooinverted500.png" width="250" class="img-responsive center-block"></a>
+				<a href="http://openoakland.org"><img src="images/ooinverted500.png" alt="Open Oakland" width="250" class="img-responsive center-block"></a>
         </div><!-- /.col-xs-6 -->
         <div class="col-xs-12 col-sm-4">
-          <img class="featurette-image img-responsive" src="images/trike500.jpg" alt="trike">
+          <img class="featurette-image img-responsive" src="images/trike500.jpg" alt="Child on Tricycle">
         </div><!-- /.col-xs-6 -->
              <div class="col-xs-12 col-sm-4">
   				<p class="text-center"><a href="mailto:earlyoakland@gmail.com"><span class="glyphicon glyphicon-send"></span> Email us</a></p>
@@ -264,10 +264,10 @@
           		<p class="text-center"> <a href="https://www.facebook.com/pages/Early-Oakland/"> <i class="fa fa-facebook-square fa-2x"></i> Like us on Facebook!</a></p>
           <p class="text-center"> <a href="https://twitter.com/EarlyOakland"><i class="fa fa-twitter fa-2x"></i> Follow us for updates</a></p>
         </div><!-- /.col-xs-6 -->
-   
+
       </div><!-- /.row -->
 </div> <!-- container -->
-      
+
 
       <!-- FOOTER -->
       <footer>
@@ -288,8 +288,8 @@
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title" id="myModalLabel">Finding and Enrolling in Early Education Programs in Oakland: </h4>
       </div>
-      
-      <div class="row featurette"> 
+
+      <div class="row featurette">
         <div class="col-md-3">
           <img class="featurette-image img-responsive" src="images/slide500.jpg" alt="slides">
         </div>
@@ -315,7 +315,7 @@
 
         </div>
       </div>
-      
+
     </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         <li data-target="#myCarousel" data-slide-to="2"></li>
       </ol>
       <div class="carousel-inner">
-        <div class="item active" style="background-image:url(images/startrotate1.jpg);">
+        <div class="item active" style="background: #833dc7 url(images/startrotate1.jpg);">
           <div class="container">
             <div class="carousel-caption">
               <img src="images/eologo180.png" alt="Early Oakland" />
@@ -78,7 +78,7 @@
             </div>
           </div>
         </div>
-        <div class="item" style="background-image:url(images/startrotate2.jpg);">
+        <div class="item" style="background: #446aa8 url(images/startrotate2.jpg);">
           <div class="container">
             <div class="carousel-caption">
               <h1>We're here to help.</h1>
@@ -87,7 +87,7 @@
             </div>
           </div>
         </div>
-        <div class="item" style="background-image:url(images/startrotate1.jpg);">
+        <div class="item" style="background: #833dc7 url(images/startrotate1.jpg);">
           <div class="container">
             <div class="carousel-caption">
               <h1>Early Learning Programs Work</h1>
@@ -149,7 +149,7 @@
 
       <div class="row featurette"> <a name="learn"></a>
         <div class="col-md-7">
-          <h2 name="learn" class="featurette-heading">How Do I Find These Services? <span class="text-muted">Easy!</span></h2>
+          <h2 name="learn" class="featurette-heading">How Do I Find These Services? <em>Easy!</em></h2>
           <p class="lead">Follow any button on this site to Find Services and you'll see a map that lets you pick your child's age, you can then see contact and enrollment information about services close to your home or work.  You can call too!</p>
           <p><a class="btn btn-lg btn-primary pull-right" href="find.html" role="button">Find Services & Enroll Now</a></p>
 

--- a/index.html
+++ b/index.html
@@ -231,16 +231,16 @@
       <!-- Three columns of text for site sponsors - rounded logos? -->
       <div class="row">
         <div class="col-xs-12 col-sm-3">
-          <a href="http://krfoundation.org/" ><img class="img-rounded" border-radius: 6px; src="images/rainin300.png" alt="rainin" width="100%"></a>
+          <a href="http://krfoundation.org/" ><img class="img-rounded" border-radius: 6px; src="images/rainin300.png" alt="Kenneth Rainin Foundation" width="100%"></a>
         </div><!-- /.col-lg-4 -->
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www.first5alameda.org" ><img class="img-rounded" border-radius: 6px; src="images/firstfive300.png" width="100%" alt="firstfive"></a>
+          <a href="http://www.first5alameda.org" ><img class="img-rounded" border-radius: 6px; src="images/firstfive300.png" width="100%" alt="First Five Alameda County"></a>
         </div><!-- /.col-lg-4 -->
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www.oaklandeducates.com/" ><img class="img-rounded" border-radius: 6px; src="images/oakedcabinet300.png" width="100%" alt="OEC"></a>
+          <a href="http://www.oaklandeducates.com/" ><img class="img-rounded" border-radius: 6px; src="images/oakedcabinet300.png" width="100%" alt="Oakland Education Cabinet"></a>
         </div><!-- /.col-lg-4 -->
         <div class="col-xs-12 col-sm-3">
-          <a href="http://www.ebcf.org" ><img class="img-rounded" border-radius: 6px; src="images/ebcf300.jpg" width="100%" alt="EBCF"></a>
+          <a href="http://www.ebcf.org" ><img class="img-rounded" border-radius: 6px; src="images/ebcf300.jpg" width="100%" alt="East Bay Community Foundation"></a>
         </div><!-- /.col-lg-4 -->
 
       </div><!-- /.row -->
@@ -281,7 +281,7 @@
 
 
 <!--MODALS!-->
-<div class="modal fade bs-example-modal-lg" id="suggestions"tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
+<div class="modal fade bs-example-modal-lg" id="suggestions"tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
@@ -291,7 +291,7 @@
 
       <div class="row featurette">
         <div class="col-md-3">
-          <img class="featurette-image img-responsive" src="images/slide500.jpg" alt="slides">
+          <img class="featurette-image img-responsive" src="images/slide500.jpg" alt="Child on slide">
         </div>
         <div class="col-md-9">
       <ul>
@@ -321,12 +321,12 @@
 </div>
 
 <!--MODALS!-->
-<div class="modal fade bs-example-modal-lg" id="faq"tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
+<div class="modal fade bs-example-modal-lg" id="faq" tabindex="-1" role="dialog" aria-labelledby="myModalLabel2" aria-hidden="true">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title" id="myModalLabel">Frequently Asked Questions</h4>
+        <h4 class="modal-title" id="myModalLabel2">Frequently Asked Questions</h4>
       </div>
       <ul class="faq">
       <li><strong>What programs are included in this website?</strong></li>


### PR DESCRIPTION
Cleaned up a lot of the things from #26 without refactoring or changing too many things, as per the README. 

My text editor deletes whitespace by default, so [preview this PR without the whitespace changes](?w=0).
## Changes
- Added new descriptive alt images. In some cases, where the image is more descriptive it might make sense to put an `alt=""`, but I wanted to replace some of the brief description to add context for screenreaders
- Fixed contrast ratio in the navbar and buttons, I changed to a slightly darker green suggested by [this color contrast tool](http://leaverou.github.io/contrast-ratio/#white-on-rgba%2834%2C%20129%2C%200%2C%201%29). Happy to try something different.
- Fixed the aria labels on the aria-labelled-by
- Added descriptive link text on links. When navigating a website with a screenreader, it's not always clear what the "learn more" refers to, so I tried changing that. If you want to go back to "Learn more", [I can use screenreader-only text to give more context](http://accessibility.oit.ncsu.edu/blog/2012/01/12/accessible-read-more-links/).
- Added backgrounds to the carousels. On slower connections the backgrounds are white and no one can read white on white text.
