### PR TITLE
Broken links

### DIFF
--- a/find.html
+++ b/find.html
@@ -215,9 +215,9 @@
             <ul>
           <li>Oakland Unified School District: 510-273-1590, <a href="http://www.ousd.k12.ca.us/domain/92">website</a></li>
           <li>Oakland Head Start: 510-238-3165, <a href="http://www2.oaklandnet.com/Government/o/DHS/o/ChildrenYouthServices/OAK022077">website</a></li>
-          <li>Unity Council: 510-535-6102 <a href="http://www.unitycouncil.org/head-start-and-early-head-start/">website</a></li>
-          <li>Ask questions about the services and learning opportunities provided, and where programs are located (link to our map), and visit them.</li>
-          <li>Be prepared to complete paperwork and present documents such as children’s birth certificates, family income, health and immunization records. proof of residency (not citizenship or immigrant status). </li>
+          <li>Unity Council Head Start: 510-535-6102 <a href="http://www.unitycouncil.org/head-start-and-early-head-start/">website</a></li>
+          <li>Ask questions about the services and learning opportunities provided, <a href="find.html">where programs are located</a>, and visit them.</li>
+          <li>Be prepared to complete paperwork and present documents such as children’s birth certificates, proof of family income, health and immunization records, and proof of residency (not citizenship or immigrant status). </li>
         </ul>
         <p>Families in transition or without permanent homes are welcome.
         You may be put on a waiting list; don’t give up!  Keep calling!</p>

--- a/find.html
+++ b/find.html
@@ -210,8 +210,8 @@
         <ul>
           <li>First- use our <a href="find.html">map tool</a> to locate a service that is convenient for you.</li>
           <li>Talk to other parents about their experiences; read materials from <a href="http://bananasinc.org">BANANAS</a> on selecting the right choice for your child and your family.</li>
-          <li>Call BANANAS for information and referrals to different types of programs -- full or part time, different age groups, private, public, subsidized, etc.  (510) 658-0381 <strong>and</strong>
-            If you think your family meets low income guidelines – or if you have a child with a special need -- call the following subsidized programs directly:</li>
+          <li>Call BANANAS for information and referrals to different types of programs -- full or part time, different age groups, private, public, subsidized, etc.  (510) 658-0381 <strong>and</strong></li>
+           <li>If you think your family meets low income guidelines – or if you have a child with a special need -- call the following subsidized programs directly:</li>
             <ul>
           <li>Oakland Unified School District: 510-273-1590, <a href="http://www.ousd.k12.ca.us/domain/92">website</a></li>
           <li>Oakland Head Start: 510-238-3165, <a href="http://www2.oaklandnet.com/Government/o/DHS/o/ChildrenYouthServices/OAK022077">website</a></li>

--- a/find.html
+++ b/find.html
@@ -220,7 +220,7 @@
           <li>Be prepared to complete paperwork and present documents such as children’s birth certificates, proof of family income, health and immunization records, and proof of residency (not citizenship or immigrant status). </li>
         </ul>
         <p>Families in transition or without permanent homes are welcome.
-        You may be put on a waiting list; don’t give up!  Keep calling!</p>
+        You may be put on a waiting list. Don’t give up!  Keep calling!</p>
         <p><a class="btn btn-lg btn-primary" href="find.html" role="button">Find Services Nearby!</a></p>
 
           </div>

--- a/find.html
+++ b/find.html
@@ -25,11 +25,10 @@
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="#">EarlyOakland</a>
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="http://www.earlyoakland.org">Home</a></li>
+              <li><a href="index.html">EarlyOakland</a></li>
               <li class="active"><a href="find.html">Find Services</a></li>
 <!--                <li><a href="#funders">Funders</a></li>
               <li><a href="#partners">Partners</a></li> -->

--- a/index.html
+++ b/index.html
@@ -41,7 +41,6 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
               </button>
-              <a class="navbar-brand" href="#">EarlyOakland</a>
             </div>
             <div class="navbar-collapse collapse">
               <ul class="nav navbar-nav">

--- a/index.html
+++ b/index.html
@@ -48,7 +48,6 @@
                 <li><a href="find.html">Find Services</a></li>
 <!--                <li><a href="#funders">Funders</a></li>
                 <li><a href="#partners">Partners</a></li> -->
-                <li><a href="#why">Learn More</a></li>
                 <li><a href="#" data-toggle="modal" data-target="#suggestions">Enrolling Steps</a></li>
                 <li><a href="#" data-toggle="modal" data-target="#faq">FAQ</a></li>
               </ul>

--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
       </ul>
       <ul>
       <li>Families in transition or without permanent homes are welcome.</li>
-      <li>You may be put on a waiting list; don’t give up!  Keep calling!</li>
+      <li>You may be put on a waiting list. Don’t give up!  Keep calling!</li>
       </ul>
       <p><a class="btn btn-lg btn-primary" href="find.html" role="button">Find Services Nearby!</a></p>
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
             </div>
             <div class="navbar-collapse collapse">
               <ul class="nav navbar-nav">
-                <li class="active"><a href="#">Home</a></li>
+                <li class="active"><a href="#">EarlyOakland</a></li>
                 <li><a href="find.html">Find Services</a></li>
 <!--                <li><a href="#funders">Funders</a></li>
                 <li><a href="#partners">Partners</a></li> -->

--- a/index.html
+++ b/index.html
@@ -301,8 +301,8 @@
         <li>Oakland Unified School District: 510-273-1590, <a href="http://www.ousd.k12.ca.us/domain/92">website</a></li>
         <li>Oakland Head Start: 510-238-3165, <a href="http://www2.oaklandnet.com/Government/o/DHS/o/ChildrenYouthServices/OAK022077">website</a></li>
         <li>Unity Council Head Start: 510-535-6102 <a href="http://www.unitycouncil.org/head-start-and-early-head-start/">website</a></li>
-        <li>Ask questions about the services and learning opportunities provided, and where programs are located (link to our map), and visit them.</li>
-        <li>Be prepared to complete paperwork and present documents such as children’s birth certificates, family income, health and immunization records. proof of residency (not citizenship or immigrant status). </li>
+        <li>Ask questions about the services and learning opportunities provided, <a href="find.html">where programs are located</a>, and visit them.</li>
+        <li>Be prepared to complete paperwork and present documents such as children’s birth certificates, proof of family income, health and immunization records, and proof of residency (not citizenship or immigrant status). </li>
       </ul>
       </ul>
       <ul>


### PR DESCRIPTION
@derekeder

To fix issue: https://github.com/openoakland/EarlyOakland/issues/24

Intro: I attended OpenOakland last night and saw that this project had some open issues, so I began working on it. 

What I did: 
- The EarlyOakland and Home links were redundant. I removed the Home link, replaced it with EarlyOakland and linked it to index.html instead of earlyoakland.org.
- The Learn More link was missing the anchor side of the link so it didn't go anywhere. Until the destination is identified, I removed the link to improve user experience.
- The Enrolling Steps: 
  - Placeholder text for a link: I removed the placeholder text and added the link.
  - Punctuation typos: I fixed them.
  - Split 1 li into 2 on find.html to reflect the same text on the index.html page.

This pull request should allow issue 24 to be closed.
